### PR TITLE
KUZ-484: Share DSL to plugins

### DIFF
--- a/source/includes/core_documentation/_04-plugins.md
+++ b/source/includes/core_documentation/_04-plugins.md
@@ -432,7 +432,7 @@ On each of following events, you can attach a function to execute in your plugin
 |`rabbit:stopped`		| / | / |Triggered when the rabbit MQ service is stopped|Type: String.<br> `'RabbitMQ Service stopped'`|
 
 
-#### The plugin context
+### The plugin context
 
 Plugins don't have access to the Kuzzle instance. Instead, Kuzzle provides a plugin ``context`` to the ``plugin.init()`` function.
 
@@ -440,6 +440,7 @@ Here is the list of shared objects contained in the provided ``context``:
 
 | Object | Purpose                      |
 |--------|------------------------------|
+| ``Dsl`` | Constructor allowing plugins to instantiate a Kuzzle DSL instance |
 | ``RequestObject`` | Constructor for standardized requests sent to Kuzzle |
 | ``ResponseObject`` | Constructor for the standardized Kuzzle non-realtime response objects |
 | ``RealTimeResponseObject`` | Constructor for the standardized Kuzzle realtime response objects |
@@ -447,12 +448,14 @@ Here is the list of shared objects contained in the provided ``context``:
 | ``repositories()`` | Getter function to the security roles, profiles and users repositories |
 | ``getRouter()`` | Getter function to the Kuzzle protocol communication system |
 
-#### Architecture
+
+
+### Architecture
 
 Your main javascript file in your plugin must have a function `init` and expose a `hooks` and/or a `pipes` and/or a `controllers` object. All functions defined in these files must be exposed as main object.
 
 
-#### The plugin init function
+### The plugin init function
 
 All plugins must expose a ``init`` function. Its purpose is to initialize the plugins according to its configuration.
 

--- a/source/includes/core_documentation/_04-plugins.md
+++ b/source/includes/core_documentation/_04-plugins.md
@@ -595,7 +595,7 @@ For this reason, Kuzzle enforce a timeout on data processing, rejecting the data
 `pipe` plugins functions must take a callback as their last parameter, and this callback must be called at the end of the processing with `callback(error, object)`:
 
 * error: if there is an error during the function, this parameter must be set with one of the available Error object provided by the plugin context. Otherwise, set it to `null`
-* object: the resulting data, given back for Kuzzle to process
+* object: the resulting data, given back to Kuzzle for processing
 
 `pipe` plugins are called in chain. When the `callback()` function is called, the next `pipe` plugin function attached on the event is triggered.   
 The order of plugin execution is not guaranteed.

--- a/source/includes/core_documentation/_04-plugins.md
+++ b/source/includes/core_documentation/_04-plugins.md
@@ -567,7 +567,7 @@ module.exports = function () {
 
 A `worker` plugin is simply a `listener` plugin running in different threads. This is especially useful to allow your plugin to perform cost-heavy operations without impeding Kuzzle performances.
 
-To convert a `listener` plugin to a `worker` one, just add a `threads: <number of threads>` to the plugin configuration.  
+To convert a `listener` plugin to a `worker` one, just add the following attribute to the plugin configuration: `threads: <number of threads>`
 If the number of configured thread is greater than 1, Kuzzle will dispatch events between these threads using round-robin.
 
 **Note:** `worker` plugins can only be launched by server instances of Kuzzle.
@@ -590,7 +590,7 @@ If the number of configured thread is greater than 1, Kuzzle will dispatch event
 
 But unlike `listener` plugins, `pipe` plugins can modify the provided data, and Kuzzle wait for these plugin to process it. `pipe` plugins can even invalidate data, resulting to an error returned to the original client.
 
-For this reason, Kuzzle enforce a timeout on data processing, rejecting the data altogether if a `pipe` plugin fails to respond in time, and forwarding an error to the original client.
+For this reason, Kuzzle enforce a timeout on data processing, rejecting the data altogether if a `pipe` plugin fails to respond in a timely fashion, and forwarding an error to the original client.
 
 `pipe` plugins functions must take a callback as their last parameter, and this callback must be called at the end of the processing with `callback(error, object)`:
 


### PR DESCRIPTION
All the following changes are made on the `plugins` section of the guide documentation:

* Promoted the following documentation sections so that they appear in the menu entries: `The plugin context` and `The plugin init function`
* Add mentions to the `Dsl constructor` in the `plugin context` section
* Add a new `Dsl constructor` section, documenting how to use the Kuzzle DSL
* Removed the `Architecture` section, as I found it difficult to understand by itself
* As a result, rewrote most of the `listener`, `worker` and `pipe` plugins sections to make explanations more detailed