### PR TITLE
use full width for image, to make them more readable

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -484,7 +484,7 @@ html, body {
   }
 
   img {
-    max-width: 60%;
+    max-width: 100%;
   }
 
   code {


### PR DESCRIPTION
As you can see for example here: http://kuzzle.io/guide/#architecture
The images size are too small (only 60% width... why ???)

This PR increases the image width to 100% of the parent div.
