### PR TITLE
Worker plugins accessors

### DIFF
--- a/source/includes/plugins/_03-plugin-context.md
+++ b/source/includes/plugins/_03-plugin-context.md
@@ -18,7 +18,13 @@ Here is the list of shared objects contained in the provided ``context``:
 | `context.constructors.ResponseObject` | Constructor for the standardized Kuzzle response objects |
 | `errors.<ErrorConstructor>` |Kuzzle error constructors, built dynamically from available Kuzzle error objects at runtime|
 
+**Note:** `context.accessors` are not available to [worker plugins](#gt-worker-plugins), as they are run in their own process(es), without access to Kuzzle instances.
+
 ### > Accessor: `passport`
+
+<aside class="notice">
+<a href="#gt-worker-plugins">Worker plugins</a> don't have access to accessors
+</aside>
 
 The `passport` accessor allow [authentication plugins](/#gt-authentication-plugin) to register a new login strategy to Kuzzle.
 
@@ -55,6 +61,10 @@ pluginContext.accessors.passport.use(new LocalStrategy(verify.bind(this)));
 ```
 
 ### > Accessor: `router`
+
+<aside class="notice">
+<a href="#gt-worker-plugins">Worker plugins</a> don't have access to accessors
+</aside>
 
 The `router` accessor allows protocol plugins to interface themselves with Kuzzle. This accessor exposes the following methods:
 
@@ -103,6 +113,10 @@ Not calling this method after a connection is dropped will result in a memory-le
 
 
 ### > Accessor: `users`
+
+<aside class="notice">
+<a href="#gt-worker-plugins">Worker plugins</a> don't have access to accessors
+</aside>
 
 The `users` accessor provides methods for handling users. This accessor is mainly used by authentication plugins.
 

--- a/source/includes/plugins/_04-creating-plugins.md
+++ b/source/includes/plugins/_04-creating-plugins.md
@@ -33,14 +33,16 @@ module.exports = function () {
 
 ### > Worker plugins
 
+<aside class="notice">
+The <a href="#the-plugin-context">plugin context</a> provided to worker plugins do not contain <code>accessors</code>
+</aside>
+
 A `worker` plugin is simply a `listener` plugin running in separate threads. This is especially useful when you have to perform cost-heavy operations without impeding Kuzzle performances.
 
 To convert a `listener` plugin to a `worker` one, just add the following attribute to the plugin configuration: `threads: <number of threads>`
 
 If this number of threads is greater than 0, Kuzzle will launch the plugin on a single separate thread.  
 If the number of configured thread is greater than 1, Kuzzle will dispatch events between these threads using round-robin.
-
-**Note:** `worker` plugins can only be launched by server instances of Kuzzle.
 
 
 Plugin configuration example:


### PR DESCRIPTION
There was a vital piece of information missing from the documentation: the fact that `worker` plugins do not have `accessors` exposed in the provided plugin context.