### PR TITLE
Filter typos

### DIFF
--- a/source/includes/user_guide/_04-filters.md
+++ b/source/includes/user_guide/_04-filters.md
@@ -41,12 +41,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > exists
@@ -90,12 +89,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > ids
@@ -139,12 +137,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > in
@@ -185,17 +182,16 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > missing
 
-A filter matching documents with missing field.
+A filter matching documents with a missing field.
 
 Given the following documents:
 
@@ -234,12 +230,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > range
@@ -305,12 +300,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > regexp
@@ -377,12 +371,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### Filter controls
@@ -391,7 +384,7 @@ Filter controls allow regrouping or inverting filters and/or geospatial filters.
 
 ### > and
 
-The `and` filter allows filtering documents on two or more terms.
+The `and` filter takes an array of filter objects, combining them with AND operands.
 
 Given the following documents:
 
@@ -447,17 +440,25 @@ var filter = {
     ]
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > bool
 
 A filter matching documents matching boolean combinations of other queries.
+
+This operand accepts the following attributes:
+
+* `must`: all listed conditions must be true
+* `must_not`: all listed conditions must be false
+* `should`: one of the listed condition must be true
+* `should_not`: one of the listed condition must be false
+
+Each one of these attributes are an array of filter objects.
 
 Given the following documents:
 
@@ -568,12 +569,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > not
@@ -620,17 +620,16 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > or
 
-The `or` filter allows combining multiple filters with a OR boolean operator.
+The `or` filter takes an array containing filter objects, combining them using OR operands.
 
 Given the following documents:
 
@@ -659,16 +658,18 @@ The following filter validates the first two documents:
 
 ```javascript
 {
-  or: {
-    equals: {
-      city: 'NYC'
+  or: [
+    {
+      equals: {
+        city: 'NYC'
+      }
+    },
+    {
+      equals: {
+        city: 'London'
+      }
     }
-  },
-  {
-    equals: {
-      city: 'London'
-    }
-  }
+  ]
 }
 ```
 
@@ -676,36 +677,37 @@ With the [JavaScript SDK](/sdk-documentation/#subscribe):
 
 ```javascript
 var filter = {
-  or: {
-    equals: {
-      city: 'NYC'
+  or: [
+      {
+      equals: {
+        city: 'NYC'
+      }
+    },
+    {
+      equals: {
+        city: 'London'
+      }
     }
-  },
-  {
-    equals: {
-      city: 'London'
-    }
-  }
+  ]
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### Geospatial filters
 
-Geospatial filters allow you to find documents containing a geolocation field (i.e. a point).
+Geospatial filters allow you to find documents containing a geolocation field.
 
-There are some inherent objects and concepts which are good to understand before going further. Most of them are taken from the ElasticSearch DSL format, some have been simplified.
+There are some inherent objects and concepts that are good to understand before going further.
 
 #### Geospatial objects and concepts
 
   * Point
-  * Bounding Box aka BBox
+  * Bounding Box
   * Polygon
   * Distance
 
@@ -713,10 +715,14 @@ There are some inherent objects and concepts which are good to understand before
 
 A point is a single longitude-latitude coordinate pair.
 
-The following notations are valid:
+The following notations are accepted and valid:
 
 ```javascript
 { lat: -74.1, lon: 40.73 }
+```
+
+```javascript
+{ lat_lon: { lat: 40.73, lon: -74.1 } }
 ```
 
 ```javascript
@@ -731,6 +737,10 @@ When coordinates are in array format, the format is [lon, lat] to comply with <a
 { latLon: [ -74.1, 40.73 ] }
 ```
 
+```javascript
+{ lat_lon: [ -74.1, 40.73 ] }
+```
+
 <aside class="note">
 As a string, the coordinates format is "lat, lon"
 </aside>
@@ -739,20 +749,28 @@ As a string, the coordinates format is "lat, lon"
 { latLon: "40.73, -74.1" }
 ```
 
+```javascript
+{ lat_lon: "40.73, -74.1" }
+```
+
 Here is the [geoHash](https://en.wikipedia.org/wiki/Geohash) representation
 
 ```javascript
 { latLon: "dr5r9ydj2" }
 ```
 
+```javascript
+{ lat_lon: "dr5r9ydj2" }
+```
+
 ##### Bounding Box
 
-A bounding box (also known as BBox) is a 2D box that can be defined using:
+A bounding box is a 2D box that can be defined using:
 
 1. 2 points coordinates tuples, defining the top left and bottom right corners of the box
-2. 4 values defining the 4 BBox sides. ```top``` and ```bottom``` are latitudes and ```left``` and ```right``` are longitudes
+2. 4 values defining the 4 box sides: ```top``` and ```bottom``` are latitudes, and ```left``` and ```right``` are longitudes
 
-All of these representations are defining the same BBox:
+All of these representations are defining the same bounding box:
 
 ```javascript
 {
@@ -770,6 +788,13 @@ All of these representations are defining the same BBox:
 }
 ```
 
+```javascript
+{
+  top_left: { lat: 40.73, lon: -74.1 },
+  bottom_right: { lat: 40.01, lon: -71.12 }
+}
+```
+
 <aside class="note">
 When cooddinates are in array format, the format is [lon, lat] to comply with <a href="http://geojson.org/">GeoJSON</a>
 </aside>
@@ -778,6 +803,13 @@ When cooddinates are in array format, the format is [lon, lat] to comply with <a
 {
   topLeft: [ -74.1, 40.73 ],
   bottomRight: [ -71.12, 40.01 ]
+}
+```
+
+```javascript
+{
+  top_left: [ -74.1, 40.73 ],
+  bottom_right: [ -71.12, 40.01 ]
 }
 ```
 
@@ -792,6 +824,13 @@ As a string, the coordinates format is "lat, lon"
 }
 ```
 
+```javascript
+{
+  top_left: "40.73, -74.1",
+  bottom_right: "40.01, -71.12"
+}
+```
+
 Here is the [geoHash](https://en.wikipedia.org/wiki/Geohash) representation
 
 ```javascript
@@ -801,12 +840,19 @@ Here is the [geoHash](https://en.wikipedia.org/wiki/Geohash) representation
 }
 ```
 
+```javascript
+{
+  top_left: "dr5r9ydj2",
+  bottom_right: "drj7teegp"
+}
+```
+
 ##### Polygon
 
 Unlike the GeoJSON representation, a polygon, here, must contain at least 3 [points](#point).  
 The last point do not have to be the same as the first one, but the points must be sorted in the right order. The polygon is automatically closed.
 
-For each polygon points, all the possible point notations are valid.
+For each polygon points, all the possible point notations are valid (see above).
 
 Example of a valid polygon representation:
 
@@ -824,6 +870,7 @@ Example of a valid polygon representation:
 ##### Distance
 
 By default, when it is not specified, the distance unit is expressed in meters.  
+Note that distance values are strings (including `from` and `to` attributes for `geoDistanceRange`)
 
 All formats supported by the [node-units](https://github.com/brettlangdon/node-units) library can be used:
 
@@ -905,12 +952,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > geoDistance
@@ -965,12 +1011,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 
@@ -1028,12 +1073,11 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```
 
 ### > geoPolygon
@@ -1096,10 +1140,9 @@ var filter = {
   }
 };
 
-var room =
-  kuzzle
-    .dataCollectionFactory('collection')
-    .subscribe(filter, function (error, result) {
-      // called each time a new notification on this filter is received
-    };
+kuzzle
+  .dataCollectionFactory('collection')
+  .subscribe(filter, function (error, result) {
+    // called each time a new notification on this filter is received
+  };
 ```

--- a/source/includes/user_guide/_04-filters.md
+++ b/source/includes/user_guide/_04-filters.md
@@ -378,9 +378,9 @@ kuzzle
   };
 ```
 
-### Filter controls
+### Filter operands
 
-Filter controls allow regrouping or inverting filters and/or geospatial filters.
+Filter operands allow combining multiple filters using boolean operands.
 
 ### > and
 

--- a/source/includes/user_guide/_04-filters.md
+++ b/source/includes/user_guide/_04-filters.md
@@ -43,9 +43,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > exists
@@ -91,9 +94,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > ids
@@ -139,9 +145,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > in
@@ -184,9 +193,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > missing
@@ -232,9 +244,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > range
@@ -302,9 +317,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > regexp
@@ -373,9 +391,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### Filter operands
@@ -442,9 +463,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > bool
@@ -573,9 +597,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > not
@@ -624,9 +651,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > or
@@ -695,9 +725,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### Geospatial filters
@@ -956,9 +989,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > geoDistance
@@ -1015,9 +1051,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 
@@ -1077,9 +1116,12 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```
 
 ### > geoPolygon
@@ -1144,7 +1186,10 @@ var filter = {
 
 kuzzle
   .dataCollectionFactory('collection')
-  .subscribe(filter, function (error, result) {
-    // called each time a new notification on this filter is received
-  };
+  .subscribe(filter, function (error, notification) {
+      // called on notification
+   })
+  .onDone(function (error, kuzzleRoom) {
+     // subscription result
+  });
 ```

--- a/source/includes/user_guide/_04-filters.md
+++ b/source/includes/user_guide/_04-filters.md
@@ -489,41 +489,42 @@ Given the following documents:
 The following filter validates the second document:
 
 ```javascript
-bool: {
-  must : [
-    {
-      in : {
-        firstName : ['Grace', 'Ada']
-      }
-    },
-    {
-      range: {
-        age: {
-          gte: 36,
-          lt: 85
+{
+  bool: {
+    must : [
+      {
+        in : {
+          firstName : ['Grace', 'Ada']
+        }
+      },
+      {
+        range: {
+          age: {
+            gte: 36,
+            lt: 85
+          }
         }
       }
-    }
-  ],
-  'must_not' : [
-    {
-      equals: {
-        city: 'NYC'
+    ],
+    'must_not' : [
+      {
+        equals: {
+          city: 'NYC'
+        }
       }
-    }
-  ],
-  should : [
-    {
-      equals : {
-        hobby : 'computer'
+    ],
+    should : [
+      {
+        equals : {
+          hobby : 'computer'
+        }
+      },
+      {
+        exists : {
+          field : 'lastName'
+        }
       }
-    },
-    {
-      exists : {
-        field : 'lastName'
-      }
-    }
-  ]
+    ]
 }
 ```
 

--- a/source/includes/user_guide/_04-filters.md
+++ b/source/includes/user_guide/_04-filters.md
@@ -525,6 +525,7 @@ The following filter validates the second document:
         }
       }
     ]
+  }
 }
 ```
 


### PR DESCRIPTION
This PR fixes some errors and typos in the `Filtering syntax` part of the guide.

* remove `subscribe` obsolete return value from Javascript SDK code examples (see https://github.com/kuzzleio/sdk-javascript/pull/112 )
* fix `or` operand examples 
* add a description of the `bool` supported attributes
* add missing geopoint supported formats
* rename `filter controls` to `filter operands` for better understanding